### PR TITLE
Vcpkg disable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
If Vcpkg is installed with Visual Studio integration (which is not uncommon), it would enable itself in all C++ projects by default, and silently mess with the build, possibly producing unexpected results. So it needs to be disabled somehow, by user or, as I suggest to consider, by preemptively disabling it for the directory/solutions to prevent possible problems.